### PR TITLE
Enable to set random seed

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,9 +75,11 @@ Parallel lda must be run in linux environment with g++ compiler and [mpich](http
       * `beta`: Suggested to be 0.01
       * `num_topics`: The total number of topics.
       * `total_iterations`: The total number of GibbsSampling iterations.
-      * `burn_in_iterations`: After --burn\_in\_iterations iteration, the model will be almost converged. Then we will average models of the last (total\_iterations-burn\_in\_iterations) iterations as the final model. This only takes effect for single processor version. For example: you set total\_iterations to 200, you found that after 170 iterations, the model is almost converged. Then you could set burn\_in\_iterations to 170 so that the final model will be the average of the last 30 iterations.
+      * `burn_in_iterations`: After --burn\_in\_iterations iteration, the model will be almost converged Then we will average models of the last (total\_iterations-burn\_in\_iterations) iterations as the final model. This only takes effect for single processor version. For example: you set total\_iterations to 200, you found that after 170 iterations, the model is almost converged. Then you could set burn\_in\_iterations to 170 so that the final model will be the average of the last 30 iterations.
       * `model_file`: The output file of the trained model.
+      * `random_seed`: The random seed used to initialize pseudorandom.
       * `training_data_file`: The training data.
+
 
 
   * Trained Model
@@ -93,6 +95,7 @@ Parallel lda must be run in linux environment with g++ compiler and [mpich](http
       * `alpha` and `beta` should be the same with training.
       * `total_iterations`: The total number of GibbsSampling iterations for an unseen document to determine its word topics. This number needs not be as much as training, usually tens of iterations is enough.
       * `burn_in_iterations`: For an unseen document, we will average the document\_topic\_distribution of the last (total\_iterations-burn\_in\_iterations) iterations as the final document\_topic\_distribution.
+      * `random_seed`: The random seed used to initialize pseudorandom.
 
 
 # Example #

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ Parallel lda must be run in linux environment with g++ compiler and [mpich](http
       * `beta`: Suggested to be 0.01
       * `num_topics`: The total number of topics.
       * `total_iterations`: The total number of GibbsSampling iterations.
-      * `burn_in_iterations`: After --burn\_in\_iterations iteration, the model will be almost converged Then we will average models of the last (total\_iterations-burn\_in\_iterations) iterations as the final model. This only takes effect for single processor version. For example: you set total\_iterations to 200, you found that after 170 iterations, the model is almost converged. Then you could set burn\_in\_iterations to 170 so that the final model will be the average of the last 30 iterations.
+      * `burn_in_iterations`: After --burn\_in\_iterations iteration, the model will be almost converged. Then we will average models of the last (total\_iterations-burn\_in\_iterations) iterations as the final model. This only takes effect for single processor version. For example: you set total\_iterations to 200, you found that after 170 iterations, the model is almost converged. Then you could set burn\_in\_iterations to 170 so that the final model will be the average of the last 30 iterations.
       * `model_file`: The output file of the trained model.
       * `random_seed`: The random seed used to initialize pseudorandom.
       * `training_data_file`: The training data.

--- a/cmd_flags.cc
+++ b/cmd_flags.cc
@@ -68,7 +68,7 @@ void LDACmdLineFlags::ParseCmdFlags(int argc, char** argv) {
       compute_likelihood_ = argv[i+1];
       ++i;
     } else if (0 == strcmp(argv[i], "--pseudo_random_seed")) {
-      pseudo_random_seed_ = atoi(argv[i+1]);
+      std::istringstream(argv[i+1]) >> pseudo_random_seed_;
       ++i;
     }
 

--- a/cmd_flags.cc
+++ b/cmd_flags.cc
@@ -32,6 +32,7 @@ LDACmdLineFlags::LDACmdLineFlags() {
   burn_in_iterations_ = -1;
   total_iterations_ = -1;
   compute_likelihood_ = "false";
+  pseudo_random_seed_ = time(NULL);
 }
 
 void LDACmdLineFlags::ParseCmdFlags(int argc, char** argv) {
@@ -65,6 +66,9 @@ void LDACmdLineFlags::ParseCmdFlags(int argc, char** argv) {
       ++i;
     } else if (0 == strcmp(argv[i], "--compute_likelihood")) {
       compute_likelihood_ = argv[i+1];
+      ++i;
+    } else if (0 == strcmp(argv[i], "--pseudo_random_seed")) {
+      pseudo_random_seed_ = atoi(argv[i+1]);
       ++i;
     }
 

--- a/cmd_flags.cc
+++ b/cmd_flags.cc
@@ -32,7 +32,7 @@ LDACmdLineFlags::LDACmdLineFlags() {
   burn_in_iterations_ = -1;
   total_iterations_ = -1;
   compute_likelihood_ = "false";
-  pseudo_random_seed_ = time(NULL);
+  random_seed_ = time(NULL);
 }
 
 void LDACmdLineFlags::ParseCmdFlags(int argc, char** argv) {
@@ -68,7 +68,7 @@ void LDACmdLineFlags::ParseCmdFlags(int argc, char** argv) {
       compute_likelihood_ = argv[i+1];
       ++i;
     } else if (0 == strcmp(argv[i], "--pseudo_random_seed")) {
-      std::istringstream(argv[i+1]) >> pseudo_random_seed_;
+      std::istringstream(argv[i+1]) >> random_seed_;
       ++i;
     }
 

--- a/cmd_flags.cc
+++ b/cmd_flags.cc
@@ -67,7 +67,7 @@ void LDACmdLineFlags::ParseCmdFlags(int argc, char** argv) {
     } else if (0 == strcmp(argv[i], "--compute_likelihood")) {
       compute_likelihood_ = argv[i+1];
       ++i;
-    } else if (0 == strcmp(argv[i], "--pseudo_random_seed")) {
+    } else if (0 == strcmp(argv[i], "--random_seed")) {
       std::istringstream(argv[i+1]) >> random_seed_;
       ++i;
     }

--- a/cmd_flags.h
+++ b/cmd_flags.h
@@ -38,6 +38,7 @@ class LDACmdLineFlags {
   int         burn_in_iterations_;
   int         total_iterations_;
   std::string compute_likelihood_;
+  unsigned    pseudo_random_seed_;
 };
 
 }  // namespace learning_lda

--- a/cmd_flags.h
+++ b/cmd_flags.h
@@ -38,7 +38,7 @@ class LDACmdLineFlags {
   int         burn_in_iterations_;
   int         total_iterations_;
   std::string compute_likelihood_;
-  unsigned    pseudo_random_seed_;
+  unsigned    random_seed_;
 };
 
 }  // namespace learning_lda

--- a/infer.cc
+++ b/infer.cc
@@ -52,7 +52,7 @@ int main(int argc, char** argv) {
   if (!flags.CheckInferringValidity()) {
     return -1;
   }
-  srand(time(NULL));
+  srand(flags.pseudo_random_seed_);
   map<string, int> word_index_map;
   ifstream model_fin(flags.model_file_.c_str());
   LDAModel model(model_fin, &word_index_map);

--- a/infer.cc
+++ b/infer.cc
@@ -52,7 +52,7 @@ int main(int argc, char** argv) {
   if (!flags.CheckInferringValidity()) {
     return -1;
   }
-  srand(flags.pseudo_random_seed_);
+  srand(flags.random_seed_);
   map<string, int> word_index_map;
   ifstream model_fin(flags.model_file_.c_str());
   LDAModel model(model_fin, &word_index_map);

--- a/lda.cc
+++ b/lda.cc
@@ -111,7 +111,7 @@ int main(int argc, char** argv) {
   if (!flags.CheckTrainingValidity()) {
     return -1;
   }
-  srand(time(NULL));
+  srand(flags.pseudo_random_seed_);
   LDACorpus corpus;
   map<string, int> word_index_map;
   CHECK_GT(LoadAndInitTrainingCorpus(flags.training_data_file_,

--- a/lda.cc
+++ b/lda.cc
@@ -111,7 +111,7 @@ int main(int argc, char** argv) {
   if (!flags.CheckTrainingValidity()) {
     return -1;
   }
-  srand(flags.pseudo_random_seed_);
+  srand(flags.random_seed_);
   LDACorpus corpus;
   map<string, int> word_index_map;
   CHECK_GT(LoadAndInitTrainingCorpus(flags.training_data_file_,

--- a/mpi_lda.cc
+++ b/mpi_lda.cc
@@ -186,7 +186,7 @@ int main(int argc, char** argv) {
     return -1;
   }
 
-  srand(flags.pseudo_random_seed_);
+  srand(flags.random_seed_);
 
   LDACorpus corpus;
   set<string> allwords;

--- a/mpi_lda.cc
+++ b/mpi_lda.cc
@@ -186,7 +186,7 @@ int main(int argc, char** argv) {
     return -1;
   }
 
-  srand(time(NULL));
+  srand(flags.pseudo_random_seed_);
 
   LDACorpus corpus;
   set<string> allwords;


### PR DESCRIPTION
Hello, thank you for this nice implementation of LDA.

I wanted to set random seed to get consistent results over several trials for my purpose, and I modified the code to enable it. This PR deals with that modification.
I add a command line option `--random_seed` to set random seed. It's optional and `time(NULL)` is used to seed pseudorandom as before when the option is unset.
I think it might be a useful feature for others, but It's don't matter for me to just close this without merging if you think it's unnecessary.

Thanks.